### PR TITLE
Add retries to publishing events

### DIFF
--- a/cts/events.py
+++ b/cts/events.py
@@ -90,7 +90,11 @@ def cache_composes_if_state_changed(session, flush_context):
 
 
 def start_to_publish_messages(session):
-    """Publish messages after data is committed to database successfully"""
+    """
+    Publish messages after data is committed to database successfully.
+
+    Messages are published asynchronously in a background thread.
+    """
     import cts.messaging as messaging
 
     with _cache_lock:
@@ -99,8 +103,6 @@ def start_to_publish_messages(session):
             msgs += compose_msgs
         log.debug("Sending messages: %s", msgs)
         if msgs:
-            try:
-                messaging.publish(msgs)
-            except Exception:
-                log.exception("Cannot publish message to bus.")
+            # Publish asynchronously - returns immediately
+            messaging.publish(msgs)
         _cached_composes.clear()

--- a/cts/messaging.py
+++ b/cts/messaging.py
@@ -22,6 +22,8 @@
 # Written by Chenxiong Qi <cqi@redhat.com>
 
 import json
+import time
+from concurrent.futures import ThreadPoolExecutor
 from logging import getLogger
 
 from cts import conf
@@ -30,34 +32,91 @@ log = getLogger(__name__)
 
 __all__ = ("publish",)
 
+# Thread pool for async message publishing (single worker to serialize message sending)
+_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="cts-messaging")
+
 
 def publish(msgs):
-    """Start to send messages to message broker"""
+    """
+    Publish messages to message broker asynchronously.
+
+    Messages are published in a background thread to avoid blocking HTTP requests.
+    Failures are logged but do not prevent the HTTP response from being sent.
+    """
     backend = _get_messaging_backend()
     if backend is not None:
-        backend(msgs)
+
+        def _send():
+            try:
+                backend(msgs)
+            except Exception:
+                log.exception("Failed to publish messages to message broker.")
+
+        _executor.submit(_send)
+
+
+def _retry_with_backoff(func, max_retries=3, initial_delay=1.0, backoff_multiplier=2.0):
+    """
+    Retry a function with exponential backoff.
+
+    Args:
+        func: Callable to retry
+        max_retries: Maximum number of retry attempts (default: 3)
+        initial_delay: Initial delay in seconds (default: 1.0)
+        backoff_multiplier: Multiplier for exponential backoff (default: 2.0)
+
+    Returns:
+        Result of the function call
+
+    Raises:
+        The last exception if all retries fail
+    """
+    delay = initial_delay
+    last_exception = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except Exception as e:
+            last_exception = e
+            if attempt < max_retries:
+                log.warning(
+                    f"UMB messaging attempt {attempt + 1}/{max_retries + 1} failed: {e}. "
+                    f"Retrying in {delay:.1f}s..."
+                )
+                time.sleep(delay)
+                delay *= backoff_multiplier
+            else:
+                log.error(f"UMB messaging failed after {max_retries + 1} attempts: {e}")
+
+    raise last_exception
 
 
 def _umb_send_msg(msgs):
-    """Send message to Unified Message Bus"""
+    """Send message to Unified Message Bus with retry logic"""
 
     import proton
     from rhmsg.activemq.producer import AMQProducer
 
-    config = {
-        "urls": conf.messaging_broker_urls,
-        "certificate": conf.messaging_cert_file,
-        "private_key": conf.messaging_key_file,
-        "trusted_certificates": conf.messaging_ca_cert,
-    }
-    with AMQProducer(**config) as producer:
-        for msg in msgs:
-            event = msg.get("event", "event")
-            topic = "%s%s" % (conf.messaging_topic_prefix, event)
-            producer.through_topic(topic)
-            outgoing_msg = proton.Message()
-            outgoing_msg.body = json.dumps(msg)
-            producer.send(outgoing_msg)
+    def _send():
+        """Inner function to send messages (will be retried on failure)"""
+        config = {
+            "urls": conf.messaging_broker_urls,
+            "certificate": conf.messaging_cert_file,
+            "private_key": conf.messaging_key_file,
+            "trusted_certificates": conf.messaging_ca_cert,
+        }
+        with AMQProducer(**config) as producer:
+            for msg in msgs:
+                event = msg.get("event", "event")
+                topic = "%s%s" % (conf.messaging_topic_prefix, event)
+                producer.through_topic(topic)
+                outgoing_msg = proton.Message()
+                outgoing_msg.body = json.dumps(msg)
+                producer.send(outgoing_msg)
+
+    # Retry the send operation with exponential backoff
+    _retry_with_backoff(_send)
 
 
 def _fedora_messaging_send_msg(msgs):


### PR DESCRIPTION
Sending of messages is moved to a background thread, so that waiting between retries does not block the user waiting for http response.

The database transaction still succeeds even if message publishing fails after all retries. Failed messages are logged for monitoring.