### PR TITLE
Create an IntegrationTestScenario

### DIFF
--- a/.tekton/README-INTEGRATION-TESTS.md
+++ b/.tekton/README-INTEGRATION-TESTS.md
@@ -1,0 +1,132 @@
+# CTS Integration Tests for Konflux CI
+
+## Overview
+
+The integration test scenario validates that the built CTS container image
+works correctly by provisioning an ephemeral environment and deploying the
+service with a real PostgreSQL database.
+
+## Files
+
+### Integration Test Scenario
+
+- **`cts-integration-test.yaml`** - IntegrationTestScenario CRD that defines
+  when and how tests run
+  - Runs automatically after successful builds
+  - References the test pipeline
+  - Marks failed builds if tests fail
+
+### Test Pipelines
+
+- **`integration-test-eaas.yaml`** - EaaS-based integration test
+  - Uses Konflux EaaS (Environment as a Service) to provision ephemeral namespace
+  - Deploys real PostgreSQL database
+  - Deploys CTS service with the built image
+  - Tests actual API functionality
+  - Automatically cleans up when pipeline completes
+  - Full integration testing with proper Kubernetes resources
+
+### Test Scripts
+
+- **`../tests/test_integration_api.py`** - Integration tests using pytest
+  - Supports both local testing and CI pipeline testing
+  - Uses pytest fixtures for clean test setup
+  - Two modes:
+    - **Direct HTTP**: `CTS_URL=http://localhost:5005 pytest tests/test_integration_api.py -v`
+    - **Kubectl exec**: `KUBECTL_POD=<pod-name> pytest tests/test_integration_api.py -v`
+  - In CI, uses kubectl exec mode to run curl commands inside the CTS pod
+  - Tests all major API endpoints
+  - Edit this file to add or modify integration tests
+
+## What Gets Tested
+
+The integration tests validate:
+
+- ✅ **Service Startup** - Container starts without errors
+- ✅ **Database Connectivity** - Migrations run successfully
+- ✅ **API Endpoints** - All major endpoints respond correctly:
+  - `GET /api/1/` - API root
+  - `GET /api/1/about/` - Version information
+  - `GET /api/1/composes/` - Compose listing
+  - `GET /api/1/openapi.json` - OpenAPI specification
+- ✅ **Error Handling** - 404 responses for invalid endpoints
+- ✅ **Pagination** - Query parameters work correctly
+
+## How It Works
+
+### In Konflux CI
+
+1. Code is pushed to the repository or PR is created
+2. Tekton build pipeline builds the container image
+3. **IntegrationTestScenario** automatically triggers
+4. Test pipeline deploys and validates the image
+5. Results are reported back to the PR/commit
+
+### Pipeline Execution Flow (EaaS approach)
+
+```
+┌─────────────────────────────┐
+│ 1. Parse Snapshot           │  Extract image URL, git URL, git revision
+└─────────────┬───────────────┘
+              │
+┌─────────────▼───────────────┐
+│ 2. Provision Environment    │  Create ephemeral namespace via EaaS
+│                             │  Returns kubeconfig secret
+└─────────────┬───────────────┘
+              │
+┌─────────────▼───────────────┐
+│ 3. Deploy PostgreSQL        │  Create Deployment & Service in ephemeral ns
+└─────────────┬───────────────┘
+              │
+┌─────────────▼───────────────┐
+│ 4. Deploy CTS Service       │  Create Deployment & Service in ephemeral ns
+└─────────────┬───────────────┘
+              │
+┌─────────────▼───────────────┐
+│ 5. Run Integration Tests    │  Clone repo, run tests via kubectl exec
+│                             │
+└─────────────┬───────────────┘
+              │
+┌─────────────▼───────────────┐
+│ 6. Automatic Cleanup        │  Ephemeral namespace deleted by EaaS
+└─────────────────────────────┘
+```
+
+## Running Tests Locally
+
+```bash
+# Point to your deployment
+CTS_URL=https://cts.example.com pytest tests/test_integration_api.py -v
+```
+
+
+## Customizing Tests
+
+### Adding New Test Cases
+
+Edit `tests/test_integration_api.py` and add new test functions:
+
+```python
+def test_my_new_feature(http_client):
+    """Test my new API endpoint"""
+    status, data = http_client.get('/api/1/my-endpoint/')
+    assert status == 200
+    assert 'expected_field' in data
+```
+
+That's it! Pytest automatically discovers and runs all `test_*` functions.
+No need to manually register tests or track results.
+
+### Modifying the Test Environment
+
+Edit `.tekton/integration-test-eaas.yaml` to change:
+
+- Database configuration (in the `deploy-database` task's Deployment spec)
+- CTS environment variables (in the `deploy-cts` task's Deployment spec)
+- Test execution logic (in the `run-tests` task's Python script)
+
+
+## Related Documentation
+
+- [Konflux Integration Tests](https://konflux-ci.dev/docs/how-tos/testing/integration/)
+- [Tekton Pipelines](https://tekton.dev/docs/pipelines/)

--- a/.tekton/README-INTEGRATION-TESTS.md
+++ b/.tekton/README-INTEGRATION-TESTS.md
@@ -128,5 +128,5 @@ Edit `.tekton/integration-test-eaas.yaml` to change:
 
 ## Related Documentation
 
-- [Konflux Integration Tests](https://konflux-ci.dev/docs/how-tos/testing/integration/)
+- [Konflux Integration Tests](https://konflux-ci.dev/docs/testing/integration/)
 - [Tekton Pipelines](https://tekton.dev/docs/pipelines/)

--- a/.tekton/README-INTEGRATION-TESTS.md
+++ b/.tekton/README-INTEGRATION-TESTS.md
@@ -29,13 +29,11 @@ service with a real PostgreSQL database.
 ### Test Scripts
 
 - **`../tests/test_integration_api.py`** - Integration tests using pytest
-  - Supports both local testing and CI pipeline testing
   - Uses pytest fixtures for clean test setup
-  - Two modes:
-    - **Direct HTTP**: `CTS_URL=http://localhost:5005 pytest tests/test_integration_api.py -v`
-    - **Kubectl exec**: `KUBECTL_POD=<pod-name> pytest tests/test_integration_api.py -v`
-  - In CI, uses kubectl exec mode to run curl commands inside the CTS pod
-  - Tests all major API endpoints
+  - Makes direct HTTP requests to CTS API
+  - Run with: `CTS_URL=http://localhost:5005 pytest tests/test_integration_api.py -v`
+  - In CI, runs in a pod deployed to the same namespace as CTS
+  - Tests all major API endpoints and workflows
   - Edit this file to add or modify integration tests
 
 ## What Gets Tested
@@ -83,12 +81,14 @@ The integration tests validate:
 └─────────────┬───────────────┘
               │
 ┌─────────────▼───────────────┐
-│ 5. Run Integration Tests    │  Clone repo, run tests via kubectl exec
-│                             │
+│ 5. Run Integration Tests    │  Create test runner pod in ephemeral ns
+│                             │  Install pytest, clone repo
+│                             │  Run tests with direct HTTP to CTS service
 └─────────────┬───────────────┘
               │
 ┌─────────────▼───────────────┐
 │ 6. Automatic Cleanup        │  Ephemeral namespace deleted by EaaS
+│                             │  (includes test runner, CTS, and database)
 └─────────────────────────────┘
 ```
 

--- a/.tekton/cts-integration-test.yaml
+++ b/.tekton/cts-integration-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: cts-integration-test
+  namespace: team-sp-rhelcmp-tenant
+  labels:
+    test.appstudio.openshift.io/optional: "false"
+spec:
+  application: cts
+  resolverRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/release-engineering/cts
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: .tekton/integration-test-eaas.yaml
+  contexts:
+  - name: service-validation
+    description: |
+      Tests the CTS container image by:
+      - Provisioning ephemeral namespace using EaaS
+      - Deploying PostgreSQL database
+      - Deploying CTS service with the built image
+      - Validating API endpoints respond correctly
+      - Testing database connectivity and migrations

--- a/.tekton/integration-test-eaas.yaml
+++ b/.tekton/integration-test-eaas.yaml
@@ -1,0 +1,476 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: cts-integration-test-eaas
+spec:
+  description: |
+    Integration test for CTS using Konflux EaaS (Environment as a Service).
+    Clones the repository, provisions an ephemeral namespace, and deploys
+    CTS with PostgreSQL for testing.
+
+  params:
+  - name: SNAPSHOT
+    description: JSON string representing the snapshot under test
+    type: string
+
+  tasks:
+  - name: parse-snapshot
+    taskSpec:
+      params:
+      - name: SNAPSHOT
+        type: string
+      results:
+      - name: image-url
+        description: Container image URL to test
+      - name: git-url
+        description: Git repository URL
+      - name: git-revision
+        description: Git revision (commit SHA)
+      steps:
+      - name: extract-metadata
+        image: quay.io/konflux-ci/appstudio-utils:latest
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "Parsing snapshot..."
+          SNAPSHOT='$(params.SNAPSHOT)'
+
+          # Extract image URL
+          IMAGE_URL=$(echo "$SNAPSHOT" | jq -r '.components[] | select(.name=="cts") | .containerImage')
+          echo -n "$IMAGE_URL" | tee $(results.image-url.path)
+          echo ""
+          echo "Image to test: $IMAGE_URL"
+
+          # Extract git repository URL
+          GIT_URL=$(echo "$SNAPSHOT" | jq -r '.components[] | select(.name=="cts") | .source.git.url')
+          echo -n "$GIT_URL" | tee $(results.git-url.path)
+          echo ""
+          echo "Git URL: $GIT_URL"
+
+          # Extract git revision
+          GIT_REVISION=$(echo "$SNAPSHOT" | jq -r '.components[] | select(.name=="cts") | .source.git.revision')
+          echo -n "$GIT_REVISION" | tee $(results.git-revision.path)
+          echo ""
+          echo "Git revision: $GIT_REVISION"
+    params:
+    - name: SNAPSHOT
+      value: $(params.SNAPSHOT)
+
+  - name: provision-environment
+    runAfter:
+    - parse-snapshot
+    taskRef:
+      params:
+      - name: name
+        value: eaas-provision-space
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-eaas-provision-space:0.1
+      - name: kind
+        value: task
+      resolver: bundles
+    params:
+    - name: ownerKind
+      value: PipelineRun
+    - name: ownerName
+      value: $(context.pipelineRun.name)
+    - name: ownerUid
+      value: $(context.pipelineRun.uid)
+
+  - name: deploy-database
+    runAfter:
+    - provision-environment
+    taskSpec:
+      params:
+      - name: kubeconfig-secret
+        type: string
+      steps:
+      - name: create-database
+        image: quay.io/konflux-ci/appstudio-utils:latest
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          # Get kubeconfig from secret
+          KUBECONFIG=/tmp/kubeconfig
+          kubectl get secret $(params.kubeconfig-secret) -o jsonpath='{.data.kubeconfig}' | base64 -d > $KUBECONFIG
+          export KUBECONFIG
+
+          echo "=========================================="
+          echo "Deploying PostgreSQL Database"
+          echo "=========================================="
+
+          # Deploy PostgreSQL
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: cts-db
+            labels:
+              app: cts-db
+          spec:
+            ports:
+            - port: 5432
+              targetPort: 5432
+            selector:
+              app: cts-db
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: cts-db
+            labels:
+              app: cts-db
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: cts-db
+            template:
+              metadata:
+                labels:
+                  app: cts-db
+              spec:
+                containers:
+                - name: postgresql
+                  image: postgres:13-alpine
+                  env:
+                  - name: POSTGRES_DB
+                    value: cts
+                  - name: POSTGRES_USER
+                    value: cts
+                  - name: POSTGRES_PASSWORD
+                    value: cts-test
+                  - name: PGDATA
+                    value: /var/lib/postgresql/data/pgdata
+                  ports:
+                  - containerPort: 5432
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "100m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "500m"
+                  readinessProbe:
+                    exec:
+                      command:
+                      - pg_isready
+                      - -U
+                      - cts
+                    initialDelaySeconds: 10
+                    periodSeconds: 5
+                    timeoutSeconds: 5
+                    failureThreshold: 6
+                  volumeMounts:
+                  - name: postgres-data
+                    mountPath: /var/lib/postgresql/data
+                volumes:
+                - name: postgres-data
+                  emptyDir: {}
+          EOF
+
+          echo "Waiting for database to be ready..."
+
+          # Check pod status first
+          echo ""
+          echo "Pod status:"
+          kubectl get pods -l app=cts-db
+
+          echo ""
+          echo "Deployment status:"
+          kubectl get deployment cts-db
+
+          # Wait with more detailed output on failure
+          if ! kubectl wait --for=condition=available --timeout=180s deployment/cts-db; then
+            echo ""
+            echo "=========================================="
+            echo "Database deployment failed! Debug info:"
+            echo "=========================================="
+
+            echo ""
+            echo "Deployment details:"
+            kubectl describe deployment cts-db
+
+            echo ""
+            echo "Pod details:"
+            kubectl describe pod -l app=cts-db
+
+            echo ""
+            echo "Pod logs (if available):"
+            kubectl logs -l app=cts-db --tail=100 || echo "No logs available"
+
+            echo ""
+            echo "Events:"
+            kubectl get events --sort-by='.lastTimestamp'
+
+            exit 1
+          fi
+
+          echo "✓ Database is ready"
+    params:
+    - name: kubeconfig-secret
+      value: $(tasks.provision-environment.results.secretRef)
+
+  - name: deploy-cts
+    runAfter:
+    - deploy-database
+    taskSpec:
+      params:
+      - name: kubeconfig-secret
+        type: string
+      - name: image-url
+        type: string
+      steps:
+      - name: create-service
+        image: quay.io/konflux-ci/appstudio-utils:latest
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          # Get kubeconfig from secret
+          KUBECONFIG=/tmp/kubeconfig
+          kubectl get secret $(params.kubeconfig-secret) -o jsonpath='{.data.kubeconfig}' | base64 -d > $KUBECONFIG
+          export KUBECONFIG
+
+          IMAGE="$(params.image-url)"
+
+          echo "=========================================="
+          echo "Deploying CTS Service"
+          echo "=========================================="
+          echo "Image: $IMAGE"
+
+          # Deploy CTS
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: cts
+            labels:
+              app: cts
+          spec:
+            ports:
+            - port: 5005
+              targetPort: 5005
+              name: http
+            selector:
+              app: cts
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: cts
+            labels:
+              app: cts
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: cts
+            template:
+              metadata:
+                labels:
+                  app: cts
+              spec:
+                initContainers:
+                - name: run-migrations
+                  image: $IMAGE
+                  env:
+                  - name: CTS_DEVELOPER_ENV
+                    value: "1"
+                  - name: SQLALCHEMY_DATABASE_URI
+                    value: "postgresql://cts:cts-test@cts-db:5432/cts"
+                  command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    set -e
+                    echo "Running database migrations..."
+                    cd /src
+                    cts-manager db upgrade
+                    echo "Migrations completed successfully"
+                containers:
+                - name: cts
+                  image: $IMAGE
+                  env:
+                  - name: CTS_DEVELOPER_ENV
+                    value: "1"
+                  - name: SQLALCHEMY_DATABASE_URI
+                    value: "postgresql://cts:cts-test@cts-db:5432/cts"
+                  ports:
+                  - containerPort: 5005
+                  resources:
+                    requests:
+                      memory: "256Mi"
+                      cpu: "200m"
+                    limits:
+                      memory: "512Mi"
+                      cpu: "1000m"
+                  readinessProbe:
+                    httpGet:
+                      path: /api/1/
+                      port: 5005
+                    initialDelaySeconds: 15
+                    periodSeconds: 5
+                    timeoutSeconds: 5
+                    failureThreshold: 12
+                  livenessProbe:
+                    httpGet:
+                      path: /api/1/
+                      port: 5005
+                    initialDelaySeconds: 30
+                    periodSeconds: 10
+                    timeoutSeconds: 5
+          EOF
+
+          echo "Waiting for CTS service to be ready..."
+
+          # Check pod status first
+          echo ""
+          echo "Pod status:"
+          kubectl get pods -l app=cts
+
+          echo ""
+          echo "Deployment status:"
+          kubectl get deployment cts
+
+          # Wait with more detailed output on failure
+          if ! kubectl wait --for=condition=available --timeout=300s deployment/cts; then
+            echo ""
+            echo "=========================================="
+            echo "CTS deployment failed! Debug info:"
+            echo "=========================================="
+
+            echo ""
+            echo "Deployment details:"
+            kubectl describe deployment cts
+
+            echo ""
+            echo "Pod details:"
+            kubectl describe pod -l app=cts
+
+            echo ""
+            echo "CTS Pod logs (if available):"
+            kubectl logs -l app=cts --tail=100 || echo "No logs available"
+
+            echo ""
+            echo "Database pod status (for reference):"
+            kubectl get pod -l app=cts-db
+
+            echo ""
+            echo "Events:"
+            kubectl get events --sort-by='.lastTimestamp' | tail -30
+
+            exit 1
+          fi
+
+          echo ""
+          echo "✓ CTS service is ready"
+    params:
+    - name: kubeconfig-secret
+      value: $(tasks.provision-environment.results.secretRef)
+    - name: image-url
+      value: $(tasks.parse-snapshot.results.image-url)
+
+  - name: run-tests
+    runAfter:
+    - deploy-cts
+    taskSpec:
+      params:
+      - name: kubeconfig-secret
+        type: string
+      - name: git-url
+        type: string
+      - name: git-revision
+        type: string
+      results:
+      - name: test-result
+        description: Test execution result
+      steps:
+      - name: clone-repository
+        image: quay.io/konflux-ci/appstudio-utils:latest
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          GIT_URL="$(params.git-url)"
+          GIT_REV="$(params.git-revision)"
+
+          echo "=========================================="
+          echo "Cloning Repository"
+          echo "=========================================="
+          echo "URL: $GIT_URL"
+          echo "Revision: $GIT_REV"
+          echo ""
+
+          # Shallow clone for faster cloning (only get the specific revision)
+          git clone --depth 1 "$GIT_URL" /workspace/cts-repo
+          cd /workspace/cts-repo
+          git fetch --depth 1 origin "$GIT_REV"
+          git checkout "$GIT_REV"
+
+          echo "✓ Repository cloned successfully"
+
+      - name: execute-tests
+        image: quay.io/konflux-ci/appstudio-utils:latest
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "=========================================="
+          echo "Running Integration Tests"
+          echo "=========================================="
+
+          # Get kubeconfig
+          KUBECONFIG=/tmp/kubeconfig
+          kubectl get secret $(params.kubeconfig-secret) -o jsonpath='{.data.kubeconfig}' | base64 -d > $KUBECONFIG
+          export KUBECONFIG
+
+          # Get the namespace and CTS pod
+          NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
+          echo "Ephemeral namespace: $NAMESPACE"
+
+          CTS_POD=$(kubectl get pod -l app=cts -n $NAMESPACE -o jsonpath='{.items[0].metadata.name}')
+          echo "CTS Pod: $CTS_POD"
+          echo ""
+
+          # Bootstrap pip and install pytest
+          python3 -m ensurepip --default-pip || dnf install -y python3-pip
+          python3 -m pip install --user pytest
+
+          # Run the tests using kubectl exec mode (with properly quoted URLs to handle & in query params)
+          # Temporarily disable exit-on-error to capture test result
+          set +e
+          KUBECTL_POD="$CTS_POD" python3 -m pytest /workspace/cts-repo/tests/test_integration_api.py -v -s -o addopts=""
+          TEST_RESULT=$?
+          set -e
+
+          if [ $TEST_RESULT -eq 0 ]; then
+            echo "passed" | tee $(results.test-result.path)
+            exit 0
+          else
+            echo "failed" | tee $(results.test-result.path)
+
+            # Show pod logs for debugging
+            echo ""
+            echo "=========================================="
+            echo "CTS Pod Logs (last 50 lines):"
+            echo "=========================================="
+
+            # kubeconfig is already set up above
+            CTS_POD=$(kubectl get pod -l app=cts -n $NAMESPACE -o jsonpath='{.items[0].metadata.name}')
+            kubectl logs $CTS_POD -n $NAMESPACE --tail=50 || true
+
+            exit 1
+          fi
+    params:
+    - name: kubeconfig-secret
+      value: $(tasks.provision-environment.results.secretRef)
+    - name: git-url
+      value: $(tasks.parse-snapshot.results.git-url)
+    - name: git-revision
+      value: $(tasks.parse-snapshot.results.git-revision)
+
+  results:
+  - name: TEST_OUTPUT
+    value: $(tasks.run-tests.results.test-result)

--- a/.tekton/integration-test-eaas.yaml
+++ b/.tekton/integration-test-eaas.yaml
@@ -387,30 +387,6 @@ spec:
       - name: test-result
         description: Test execution result
       steps:
-      - name: clone-repository
-        image: quay.io/konflux-ci/appstudio-utils:latest
-        script: |
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          GIT_URL="$(params.git-url)"
-          GIT_REV="$(params.git-revision)"
-
-          echo "=========================================="
-          echo "Cloning Repository"
-          echo "=========================================="
-          echo "URL: $GIT_URL"
-          echo "Revision: $GIT_REV"
-          echo ""
-
-          # Shallow clone for faster cloning (only get the specific revision)
-          git clone --depth 1 "$GIT_URL" /workspace/cts-repo
-          cd /workspace/cts-repo
-          git fetch --depth 1 origin "$GIT_REV"
-          git checkout "$GIT_REV"
-
-          echo "✓ Repository cloned successfully"
-
       - name: execute-tests
         image: quay.io/konflux-ci/appstudio-utils:latest
         script: |
@@ -426,38 +402,78 @@ spec:
           kubectl get secret $(params.kubeconfig-secret) -o jsonpath='{.data.kubeconfig}' | base64 -d > $KUBECONFIG
           export KUBECONFIG
 
-          # Get the namespace and CTS pod
+          # Get the namespace
           NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
           echo "Ephemeral namespace: $NAMESPACE"
-
-          CTS_POD=$(kubectl get pod -l app=cts -n $NAMESPACE -o jsonpath='{.items[0].metadata.name}')
-          echo "CTS Pod: $CTS_POD"
           echo ""
 
-          # Bootstrap pip and install pytest
-          python3 -m ensurepip --default-pip || dnf install -y python3-pip
-          python3 -m pip install --user pytest
+          echo "Creating test runner pod in namespace: $NAMESPACE"
 
-          # Run the tests using kubectl exec mode (with properly quoted URLs to handle & in query params)
-          # Temporarily disable exit-on-error to capture test result
+          # Create a test runner pod in the target namespace (using appstudio-utils which has git and python)
+          kubectl run cts-test-runner \
+            --image=quay.io/konflux-ci/appstudio-utils:latest \
+            --namespace=$NAMESPACE \
+            --restart=Never \
+            --command -- sleep 3600
+
+          # Wait for pod to be ready
+          echo "Waiting for test runner pod to be ready..."
+          kubectl wait --for=condition=Ready pod/cts-test-runner -n $NAMESPACE --timeout=60s
+
+          GIT_URL='$(params.git-url)'
+          GIT_REV='$(params.git-revision)'
+
+          echo ""
+          echo "Running tests in pod..."
+          echo "CTS URL: http://cts:5005"
+          echo ""
+
+          # Run the tests - temporarily disable exit-on-error to capture result
           set +e
-          KUBECTL_POD="$CTS_POD" python3 -m pytest /workspace/cts-repo/tests/test_integration_api.py -v -s -o addopts=""
+          kubectl exec cts-test-runner -n $NAMESPACE -- bash -c "
+            set -ex
+            export HOME=/tmp
+
+            echo 'Installing pytest...'
+            python3 -m ensurepip
+            python3 -m pip install --user pytest
+
+            echo ''
+            echo 'Cloning repository...'
+            cd /tmp
+            git clone --depth 1 '$GIT_URL' cts-repo
+            cd cts-repo
+            git fetch --depth 1 origin '$GIT_REV'
+            git checkout '$GIT_REV'
+
+            echo ''
+            echo 'Running pytest...'
+            CTS_URL=http://cts:5005 python3 -m pytest tests/test_integration_api.py -v -s -o addopts=
+          "
           TEST_RESULT=$?
           set -e
 
+          # Clean up test runner pod
+          echo ""
+          echo "Cleaning up test runner pod..."
+          kubectl delete pod cts-test-runner -n $NAMESPACE --ignore-not-found=true
+
           if [ $TEST_RESULT -eq 0 ]; then
+            echo ""
+            echo "✓ All tests passed!"
             echo "passed" | tee $(results.test-result.path)
             exit 0
           else
+            echo ""
+            echo "✗ Tests failed!"
             echo "failed" | tee $(results.test-result.path)
 
-            # Show pod logs for debugging
+            # Show CTS pod logs for debugging
             echo ""
             echo "=========================================="
             echo "CTS Pod Logs (last 50 lines):"
             echo "=========================================="
 
-            # kubeconfig is already set up above
             CTS_POD=$(kubectl get pod -l app=cts -n $NAMESPACE -o jsonpath='{.items[0].metadata.name}')
             kubectl logs $CTS_POD -n $NAMESPACE --tail=50 || true
 

--- a/conf/config.py
+++ b/conf/config.py
@@ -1,3 +1,4 @@
+import os
 from os import path
 
 
@@ -84,6 +85,12 @@ class DevConfiguration(BaseConfiguration):
     LOG_LEVEL = "debug"
     AUTH_BACKEND = "noauth"
     AUTH_OPENIDC_USERINFO_URI = "https://iddev.fedorainfracloud.org/openidc/UserInfo"
+
+    # Allow overriding database URI via environment variable for integration testing
+    # and docker-compose setups
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "SQLALCHEMY_DATABASE_URI", BaseConfiguration.SQLALCHEMY_DATABASE_URI
+    )
 
 
 class TestConfiguration(BaseConfiguration):

--- a/tests/test_integration_api.py
+++ b/tests/test_integration_api.py
@@ -1,0 +1,479 @@
+"""
+Integration tests for CTS API endpoints.
+
+Run with pytest in one of two modes:
+
+1. Direct HTTP mode (local testing):
+   CTS_URL=http://localhost:5005 pytest tests/test_integration_api.py -v
+
+2. Kubectl exec mode (CI testing):
+   KUBECTL_POD=cts-abc123 pytest tests/test_integration_api.py -v
+
+   Uses kubectl exec to run curl inside the CTS pod. URLs are properly quoted
+   to handle special characters like & in query parameters.
+"""
+
+import json
+import os
+import subprocess
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+
+class HTTPClient:
+    """HTTP client that works in both direct and kubectl exec modes"""
+
+    def __init__(self, base_url=None, kubectl_pod=None):
+        self.base_url = base_url.rstrip("/") if base_url else None
+        self.kubectl_pod = kubectl_pod
+
+    def _request(self, method, path, json_data=None):
+        """Make HTTP request with specified method"""
+        if self.kubectl_pod:
+            # Kubectl exec mode - use curl
+            # Important: Quote the URL to prevent shell interpretation of & and other special chars
+            url = f"http://localhost:5005{path}"
+            if json_data:
+                json_str = json.dumps(json_data).replace("'", "'\\''")
+                cmd = f"curl -s -w '\\n%{{http_code}}' -X {method} -H 'Content-Type: application/json' -d '{json_str}' '{url}'"
+            else:
+                cmd = f"curl -s -w '\\n%{{http_code}}' -X {method} '{url}'"
+
+            result = subprocess.run(
+                ["kubectl", "exec", "-i", self.kubectl_pod, "--", "sh", "-c", cmd],
+                capture_output=True,
+                text=True,
+            )
+
+            # Parse output: last line is status code, rest is body
+            lines = result.stdout.rsplit("\n", 1)
+            if len(lines) == 2:
+                body, status_code = lines
+                try:
+                    status = int(status_code)
+                except ValueError:
+                    body = result.stdout
+                    status = 200 if result.returncode == 0 else 500
+            else:
+                body = result.stdout
+                status = 200 if result.returncode == 0 else 500
+
+            # Try to parse as JSON
+            try:
+                return status, json.loads(body) if body.strip() else {}
+            except json.JSONDecodeError:
+                return status, body
+        else:
+            # Direct HTTP mode
+            url = f"{self.base_url}{path}"
+            req = Request(url, method=method)
+            if json_data:
+                req.add_header("Content-Type", "application/json")
+                req.data = json.dumps(json_data).encode("utf-8")
+
+            try:
+                with urlopen(req, timeout=10) as response:
+                    data = response.read()
+                    if response.headers.get("Content-Type", "").startswith(
+                        "application/json"
+                    ):
+                        return response.status, json.loads(data)
+                    return response.status, data.decode("utf-8")
+            except HTTPError as e:
+                # Try to read error body
+                try:
+                    error_data = e.read()
+                    if e.headers.get("Content-Type", "").startswith("application/json"):
+                        return e.code, json.loads(error_data)
+                    return e.code, error_data.decode("utf-8")
+                except:
+                    return e.code, None
+            except URLError as e:
+                raise Exception(f"Failed to connect to {url}: {e}")
+
+    def get(self, path):
+        """Make HTTP GET request"""
+        return self._request("GET", path)
+
+    def post(self, path, json_data):
+        """Make HTTP POST request"""
+        return self._request("POST", path, json_data)
+
+    def patch(self, path, json_data):
+        """Make HTTP PATCH request"""
+        return self._request("PATCH", path, json_data)
+
+    def delete(self, path):
+        """Make HTTP DELETE request"""
+        return self._request("DELETE", path)
+
+
+@pytest.fixture(scope="module")
+def http_client():
+    """HTTP client fixture that auto-detects mode from environment"""
+    kubectl_pod = os.environ.get("KUBECTL_POD")
+    base_url = os.environ.get("CTS_URL")
+
+    if kubectl_pod:
+        print(f"\nUsing kubectl exec mode (pod: {kubectl_pod})")
+        return HTTPClient(kubectl_pod=kubectl_pod)
+    elif base_url:
+        print(f"\nUsing direct HTTP mode (URL: {base_url})")
+        return HTTPClient(base_url=base_url)
+    else:
+        pytest.skip("Must set either CTS_URL or KUBECTL_POD environment variable")
+
+
+def _create_compose_info(
+    release_short, release_version, date, compose_type="test", respin=1
+):
+    """Helper to create a properly structured compose_info object"""
+    compose_id = f"{release_short}-{release_version}-{date}.{compose_type[0]}.{respin}"
+    return {
+        "header": {"version": "1.2", "type": "productmd.composeinfo"},
+        "payload": {
+            "compose": {
+                "id": compose_id,
+                "type": compose_type,
+                "date": date,
+                "respin": respin,
+            },
+            "release": {
+                "name": release_short,
+                "short": release_short,
+                "version": release_version,
+                "is_layered": False,
+                "type": "ga",
+                "internal": False,
+            },
+            "variants": {},
+        },
+    }
+
+
+# Helper functions for common test operations
+
+
+def create_tag(http_client, name, description, documentation):
+    """Create a tag and return the response data"""
+    tag_data = {
+        "name": name,
+        "description": description,
+        "documentation": documentation,
+    }
+    status, data = http_client.post("/api/1/tags/", tag_data)
+    assert status == 200, f"Failed to create tag: {data}"
+    assert isinstance(data, dict)
+    assert data["name"] == name
+    assert "id" in data
+    return data
+
+
+def import_compose(
+    http_client, release_short, release_version, date, compose_type="test", respin=1
+):
+    """Import a compose and return the response data"""
+    compose_info = _create_compose_info(
+        release_short, release_version, date, compose_type, respin
+    )
+    status, data = http_client.post("/api/1/composes/", {"compose_info": compose_info})
+    assert status == 200, f"Failed to import compose: {data}"
+    assert isinstance(data, dict)
+    assert "payload" in data
+    assert "compose" in data["payload"]
+    return data
+
+
+def tag_compose(http_client, compose_id, tag_name):
+    """Tag a compose and return the response data"""
+    status, data = http_client.patch(
+        f"/api/1/composes/{compose_id}", {"action": "tag", "tag": tag_name}
+    )
+    assert status == 200, f"Failed to tag compose: {data}"
+    assert tag_name in data.get("tags", [])
+    return data
+
+
+def untag_compose(http_client, compose_id, tag_name):
+    """Untag a compose and return the response data"""
+    status, data = http_client.patch(
+        f"/api/1/composes/{compose_id}", {"action": "untag", "tag": tag_name}
+    )
+    assert status == 200, f"Failed to untag compose: {data}"
+    assert tag_name not in data.get("tags", [])
+    return data
+
+
+def _manage_tag_user(http_client, tag_id, action, username):
+    """Internal helper to manage tag users (taggers/untaggers)"""
+    status, data = http_client.patch(
+        f"/api/1/tags/{tag_id}", {"action": action, "username": username}
+    )
+    assert status == 200, f"Failed to {action}: {data}"
+
+    list_name = action.rsplit("_", 1)[1] + "s"
+
+    if action.startswith("add_"):
+        assert username in data[list_name], f"Expected {username} in {list_name}"
+    else:
+        assert (
+            username not in data[list_name]
+        ), f"Expected {username} not in {list_name}"
+
+    return data
+
+
+def add_tagger(http_client, tag_id, username):
+    """Add a tagger to a tag and return the response data"""
+    return _manage_tag_user(http_client, tag_id, "add_tagger", username)
+
+
+def remove_tagger(http_client, tag_id, username):
+    """Remove a tagger from a tag and return the response data"""
+    return _manage_tag_user(http_client, tag_id, "remove_tagger", username)
+
+
+def add_untagger(http_client, tag_id, username):
+    """Add an untagger to a tag and return the response data"""
+    return _manage_tag_user(http_client, tag_id, "add_untagger", username)
+
+
+def remove_untagger(http_client, tag_id, username):
+    """Remove an untagger from a tag and return the response data"""
+    return _manage_tag_user(http_client, tag_id, "remove_untagger", username)
+
+
+# Tests
+
+
+def test_api_root(http_client):
+    """Test that API root endpoint responds with documentation"""
+    status, data = http_client.get("/api/1/")
+    assert status == 200
+    # API root returns HTML documentation page
+    assert isinstance(
+        data, str
+    ), f"Expected HTML response (str), got {type(data).__name__}"
+    assert "<!DOCTYPE html>" in data or "<html" in data, "Expected HTML content"
+
+
+def test_about_endpoint(http_client):
+    """Test the /about endpoint returns version information"""
+    status, data = http_client.get("/api/1/about/")
+    assert status == 200
+    assert isinstance(data, dict)
+    assert "version" in data
+    print(f"  CTS version: {data['version']}")
+
+
+def test_composes_list(http_client):
+    """Test listing composes endpoint"""
+    status, data = http_client.get("/api/1/composes/")
+    assert status == 200
+    assert isinstance(data, dict)
+    assert "items" in data
+    print(f"  Found {len(data['items'])} composes")
+
+
+def test_composes_pagination(http_client):
+    """Test that pagination parameters work correctly"""
+    # Import 3 test composes
+    compose_ids = []
+    for i in range(1, 4):
+        response = import_compose(http_client, "PaginationTest", "1.0", f"2025010{i}")
+        compose_ids.append(response["payload"]["compose"]["id"])
+
+    print(f"  Imported {len(compose_ids)} composes for pagination test")
+
+    # Test page 1 with per_page=2
+    status, data = http_client.get("/api/1/composes/?page=1&per_page=2")
+    assert status == 200
+    assert isinstance(data, dict)
+    assert "items" in data
+    assert "meta" in data
+    assert (
+        len(data["items"]) == 2
+    ), f"Expected exactly 2 items on page 1, got {len(data['items'])}"
+    assert data["meta"]["per_page"] == 2
+    assert data["meta"]["page"] == 1
+    total = data["meta"]["total"]
+    print(f"  Page 1 (per_page=2): {len(data['items'])} items, total: {total}")
+
+    # Test page 2 with per_page=2 - should have 1 item (we imported 3 total)
+    status, data = http_client.get("/api/1/composes/?page=2&per_page=2")
+    assert status == 200
+    assert "items" in data
+    assert (
+        len(data["items"]) >= 1
+    ), f"Expected at least 1 item on page 2, got {len(data['items'])}"
+    assert data["meta"]["page"] == 2
+    print(f"  Page 2 (per_page=2): {len(data['items'])} items")
+    print("  ✓ Pagination working correctly with per_page=2")
+
+
+def test_openapi_spec(http_client):
+    """Test that OpenAPI specification is accessible"""
+    status, data = http_client.get("/static/openapispec.json")
+    assert status == 200
+    assert isinstance(data, dict)
+    assert "paths" in data
+    print(f"  API has {len(data['paths'])} endpoints")
+
+
+def test_tags_endpoint(http_client):
+    """Test tags listing endpoint"""
+    status, data = http_client.get("/api/1/tags/")
+    assert status == 200
+    assert isinstance(data, dict)
+
+
+def test_404_handling(http_client):
+    """Test that non-existent endpoints return 404"""
+    status, _ = http_client.get("/api/1/nonexistent/")
+    assert status == 404
+
+
+# Workflow tests
+
+
+def test_workflow_tag_creation(http_client):
+    """Test creating a tag and managing taggers/untaggers"""
+    # Step 1: Create a tag
+    data = create_tag(
+        http_client,
+        "integration-test-tag",
+        "Tag created during integration testing",
+        "https://example.com/docs/integration-test",
+    )
+    tag_id = data["id"]
+    print(f"  1. Created tag: {data['name']} (ID: {tag_id})")
+
+    # Verify initial state - no taggers/untaggers
+    assert data["taggers"] == []
+    assert data["untaggers"] == []
+    print(f"  2. Initial taggers: {data['taggers']}, untaggers: {data['untaggers']}")
+
+    # Step 2: Add a tagger
+    data = add_tagger(http_client, tag_id, "test-user")
+    print(f"  3. Added tagger 'test-user': taggers={data['taggers']}")
+
+    # Step 3: Add an untagger
+    data = add_untagger(http_client, tag_id, "other-user")
+    assert "test-user" in data["taggers"]
+    print(f"  4. Added untagger 'other-user': untaggers={data['untaggers']}")
+
+    # Step 4: Add another tagger
+    data = add_tagger(http_client, tag_id, "another-user")
+    assert set(data["taggers"]) == {"test-user", "another-user"}
+    print(f"  5. Added tagger 'another-user': taggers={data['taggers']}")
+
+    # Step 5: Remove a tagger
+    data = remove_tagger(http_client, tag_id, "test-user")
+    assert "another-user" in data["taggers"]
+    print(f"  6. Removed tagger 'test-user': taggers={data['taggers']}")
+
+    # Step 6: Remove the untagger
+    data = remove_untagger(http_client, tag_id, "other-user")
+    print(f"  7. Removed untagger 'other-user': untaggers={data['untaggers']}")
+
+    # Step 7: Verify final state
+    status, final_data = http_client.get(f"/api/1/tags/{tag_id}")
+    assert status == 200
+    assert final_data["taggers"] == ["another-user"]
+    assert final_data["untaggers"] == []
+    print(
+        f"  8. Final state - taggers: {final_data['taggers']}, untaggers: {final_data['untaggers']}"
+    )
+    print("  ✓ Tag creation and tagger/untagger management completed successfully")
+
+
+def test_workflow_compose_import(http_client):
+    """Test importing a compose"""
+    data = import_compose(http_client, "IntegrationTest", "1.0", "20250101")
+    compose_id = data["payload"]["compose"]["id"]
+    print(f"  Imported compose: {compose_id}")
+
+
+def test_workflow_respin_increment(http_client):
+    """Test that respin numbers are automatically incremented for duplicate composes"""
+    # Import first compose
+    response1 = import_compose(http_client, "RespinTest", "1.0", "20250102")
+    compose_id1 = response1["payload"]["compose"]["id"]
+    respin1 = response1["payload"]["compose"]["respin"]
+    print(f"  1. First compose: {compose_id1} (respin: {respin1})")
+
+    # Import second compose with same release/date - respin should auto-increment
+    response2 = import_compose(http_client, "RespinTest", "1.0", "20250102")
+    compose_id2 = response2["payload"]["compose"]["id"]
+    respin2 = response2["payload"]["compose"]["respin"]
+    print(f"  2. Second compose: {compose_id2} (respin: {respin2})")
+
+    # Import third compose - respin should increment again
+    response3 = import_compose(http_client, "RespinTest", "1.0", "20250102")
+    compose_id3 = response3["payload"]["compose"]["id"]
+    respin3 = response3["payload"]["compose"]["respin"]
+    print(f"  3. Third compose: {compose_id3} (respin: {respin3})")
+
+    # Verify respin numbers are incremented
+    assert (
+        respin2 == respin1 + 1
+    ), f"Second respin should be {respin1 + 1}, got {respin2}"
+    assert (
+        respin3 == respin2 + 1
+    ), f"Third respin should be {respin2 + 1}, got {respin3}"
+
+    # Verify compose IDs reflect the correct respin numbers
+    assert f".t.{respin1}" in compose_id1
+    assert f".t.{respin2}" in compose_id2
+    assert f".t.{respin3}" in compose_id3
+
+    print(f"  ✓ Respin auto-increment verified: {respin1} → {respin2} → {respin3}")
+
+
+def test_workflow_full_lifecycle(http_client):
+    """Test complete workflow: create tag, import compose, tag it, untag it"""
+    # Step 1: Create a tag
+    tag_response = create_tag(
+        http_client,
+        "workflow-test",
+        "Tag for workflow testing",
+        "https://example.com/docs/workflow",
+    )
+    tag_id = tag_response["id"]
+    tag_name = tag_response["name"]
+    print(f"  1. Created tag: {tag_name} (ID: {tag_id})")
+
+    # Step 2: Import a compose
+    compose_response = import_compose(http_client, "WorkflowTest", "1.0", "20250101")
+    compose_id = compose_response["payload"]["compose"]["id"]
+    print(f"  2. Imported compose: {compose_id}")
+
+    # Verify compose has no tags initially
+    status, compose_data = http_client.get(f"/api/1/composes/{compose_id}")
+    assert status == 200
+    assert "tags" in compose_data
+    initial_tags = compose_data.get("tags", [])
+    print(f"  3. Initial tags: {initial_tags}")
+
+    # Step 3: Tag the compose
+    tag_result = tag_compose(http_client, compose_id, tag_name)
+    print(f"  4. Tagged compose with '{tag_name}': {tag_result.get('tags', [])}")
+
+    # Step 4: Verify tag was applied
+    status, compose_data = http_client.get(f"/api/1/composes/{compose_id}")
+    assert status == 200
+    assert tag_name in compose_data.get("tags", [])
+    print(f"  5. Verified tags: {compose_data.get('tags', [])}")
+
+    # Step 5: Untag the compose
+    untag_result = untag_compose(http_client, compose_id, tag_name)
+    print(f"  6. Untagged compose: {untag_result.get('tags', [])}")
+
+    # Step 6: Verify tag was removed
+    status, compose_data = http_client.get(f"/api/1/composes/{compose_id}")
+    assert status == 200
+    assert tag_name not in compose_data.get("tags", [])
+    print(f"  7. Final tags: {compose_data.get('tags', [])}")
+    print("  ✓ Full workflow completed successfully")


### PR DESCRIPTION
This patch adds a definition for an integration test that is triggered by Konflux after each build. The test exercises most of the API.

The `.tekton/cts-integration-test.yaml` is the actual K8S CRD that needs to be created in the cluster.

The test pipeline uses an ephemeral namespace in which it starts a PostgreSQL database and CTS from the currently built image.

There is a code change in the service itself to enable setting database URL in DevConfiguration.

Most of the yamls have been generated by Claude Code.

I have manually created the ITS in the public cluster to use the pipeline from this branch. Once/If merged, it needs to be updated (though ideally it should be deployed through gitops).