### PR TITLE
Drop fedora-messaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN dnf -y --setopt=install_weak_deps=False update \
         mod_ldap \
         mod_ssl \
         python3-defusedxml \
-        python3-fedora \
         python3-flask \
         python3-flask-login \
         python3-flask-migrate \

--- a/conf/config.py
+++ b/conf/config.py
@@ -55,7 +55,7 @@ class BaseConfiguration(object):
 
     # Select backend where message will be sent to. Currently, umb is supported
     # which means the Unified Message Bus.
-    MESSAGING_BACKEND = ""  # fedora-messaging or umb
+    MESSAGING_BACKEND = ""  # rhmsg
 
     # List of broker URLs. Each of them is a string consisting of domain and
     # optiona port.

--- a/cts/config.py
+++ b/cts/config.py
@@ -144,7 +144,7 @@ class Config(object):
         "messaging_backend": {
             "type": str,
             "default": "",
-            "desc": "Messaging backend, rhmsg or fedora-messaging.",
+            "desc": "Messaging backend, rhmsg.",
         },
         "messaging_broker_urls": {
             "type": list,
@@ -169,7 +169,7 @@ class Config(object):
         "messaging_topic_prefix": {
             "type": str,
             "default": "cts.",
-            "desc": "Prefix for AMQP or fedora-messaging messages.",
+            "desc": "Prefix for AMQP messages.",
         },
         "oidc_base_namespace": {
             "type": str,

--- a/cts/messaging.py
+++ b/cts/messaging.py
@@ -60,23 +60,9 @@ def _umb_send_msg(msgs):
             producer.send(outgoing_msg)
 
 
-def _fedora_messaging_send_msg(msgs):
-    """Send message to fedora-messaging."""
-    from fedora_messaging import api, config
-
-    config.conf.setup_logging()
-
-    for msg in msgs:
-        event = msg.get("event", "event")
-        topic = "%s%s" % (conf.messaging_topic_prefix, event)
-        api.publish(api.Message(topic=topic, body=msg))
-
-
 def _get_messaging_backend():
     if conf.messaging_backend == "rhmsg":
         return _umb_send_msg
-    elif conf.messaging_backend == "fedora-messaging":
-        return _fedora_messaging_send_msg
     elif conf.messaging_backend:
         raise ValueError("Unknown messaging backend {0}".format(conf.messaging_backend))
     else:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,7 +21,7 @@ For production env running via httpd for example, `openapispec.json` should be s
 Messaging API
 =============
 
-CTS also sends AMQP or fedora-messaging messages when Compose changes.
+CTS also sends AMQP messages when Compose changes.
 
 Topic: cts.compose-created
 --------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python-fedora
 sqlalchemy<2.0  # For Flask 2.2.3
 Flask==2.2.3  # Pin version for Flask-Login
 Flask-Migrate


### PR DESCRIPTION
The service was never deployed for Fedora, let's not pull in the extra dependency for that.