### PR TITLE
Measure test coverage in CI

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -10,6 +10,8 @@ jobs:
   tests:
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     container:
       image: quay.io/exd-guild-compose/cts:latest
 
@@ -20,6 +22,7 @@ jobs:
           sudo dnf update -y &&
           sudo dnf install -y
           findutils
+          git-core
           make
           python3-ldap
           python3-mock
@@ -35,3 +38,9 @@ jobs:
         run: tox -e docs
       - name: tests
         run: tox -e py3
+      - uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
         -W "ignore:inspect.getargspec:DeprecationWarning" \
         -W "ignore:This method will be removed in future versions.  Use 'parser.read_file()':DeprecationWarning" \
         -W "ignore:Use .persist_selectable:DeprecationWarning" \
+        --cov-report=xml \
         {posargs}
 sitepackages = True
 


### PR DESCRIPTION
> 🤖 This was posted automatically by an AI agent.

## Summary

Adds test coverage measurement and CodeCov upload to the CI pipeline.

## Changes

- **`tox.ini`**: Added `--cov-report=xml` to the `pytest` command so that `pytest-cov` generates a `coverage.xml` file alongside the existing terminal report on every test run.
- **`.github/workflows/gating.yaml`**: Added a `codecov/codecov-action@v5` step after the `tests` step to upload `coverage.xml` to CodeCov using OIDC authentication.

## How it works

The `[pytest] addopts` section in `tox.ini` already included `--cov=cts`, so coverage was being measured but only reported to the terminal. Adding `--cov-report=xml` causes `pytest-cov` to also write `coverage.xml` to the working directory. The new CI step picks up that file and uploads it to CodeCov.

Closes #76
